### PR TITLE
Limit spots number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WiFi Spot explorer API
 
-クエリパラメータ radius, latitude, longitude によって指定した緯度latitude経度longitudeから半径raidusメートル以内にあるwifiスポットをjsonファイルとして返してくれるAPIです。
+クエリパラメータ radius, latitude, longitude , limitによって指定した緯度latitude経度longitudeから半径raidusメートル以内にあるwifiスポットをlimit件、jsonファイルとして返してくれるAPIです。
 
 ## 環境
 ruby 2.4.0
@@ -35,9 +35,9 @@ CSVファイルからDBにWiFiスポットのデータを入れます。デー�
   ```
   でサーバーを立ち上げて、
   ```
-   http://localhost:3000/api/v1/spots?radius=RADIUS_HERE&longitude=LONGITUDE_HERE&latitude=LATITUDE_HERE
+   http://localhost:3000/api/v1/spots?radius=1000&longitude=139.767052&latitude=35.681167&limit=10
   ```
-  を叩くと結果が返ってきます。radiusの値を省略した場合には、指定した緯度経度から 500m 以内のwifi spot を探します。
+  を叩くと結果が返ってきます。radiusの値を省略した場合には、指定した緯度経度から 500m 以内のwifi spot を探します。また、limitパラメータを省略した場合にはレスポンス件数を5件に制限します。
 
 ## Heroku
 [Herokuリンクはこちら]()

--- a/app/controllers/api/v1/spots_controller.rb
+++ b/app/controllers/api/v1/spots_controller.rb
@@ -22,13 +22,20 @@ module Api
 
         # limitパラメータ
         if not params[:limit].nil?
-          limit = params[:limit]
+          limit = params[:limit].to_i
         else
           limit = 5
         end
 
+        spot = Spot.within(radius, :origin => [lat, lng])
+
+        # limitパラメータがwifiスポットのヒット件数より大きい場合の処理
+        if limit > spot.count
+          limit = spot.count
+        end
+
         # radiusメートル以内のスポットを検索して、jsonファイルにして表示
-        render json: Spot.within(radius, :origin => [lat, lng]).limit(limit)
+        render json: spot.limit(limit)
       end
 
       # GET /api/v1/spots/1

--- a/app/controllers/api/v1/spots_controller.rb
+++ b/app/controllers/api/v1/spots_controller.rb
@@ -13,14 +13,22 @@ module Api
         lat = params[:latitude].to_f
         lng = params[:longitude].to_f
 
+        # radiusパラメータ
         if not params[:radius].nil?
          radius = params[:radius].to_i # km -> m
         elsif params[:raius].nil?
          radius = 500
         end
 
+        # limitパラメータ
+        if not params[:limit].nil?
+          limit = params[:limit]
+        else
+          limit = 5
+        end
+
         # radiusメートル以内のスポットを検索して、jsonファイルにして表示
-        render json: Spot.within(radius, :origin => [lat, lng])
+        render json: Spot.within(radius, :origin => [lat, lng]).limit(limit)
       end
 
       # GET /api/v1/spots/1


### PR DESCRIPTION
表示件数を limit クエリパラメータで制限できるようにした。デフォルトは limit = 5。

また、指定したlimit件数よりもヒットしたスポット数が少ない場合は、limit = ヒット件数 とすることで対応した。